### PR TITLE
Bump quarkus.version from 3.15.1 to 3.16.0

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CAConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CAConfig.java
@@ -3,9 +3,6 @@ package io.quarkiverse.certmanager.deployment;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface CAConfig {
     /**
      * The name of the secret used to sign Certificates issued by this Issuer.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateConfig.java
@@ -110,25 +110,25 @@ public interface CertificateConfig {
     Optional<List<String>> usages();
 
     /**
-     * @return options to control private keys used for the Certificate.
+     * Options to control private keys used for the Certificate.
      */
     Optional<CertificatePrivateKeyConfig> privateKey();
 
     /**
-     * @return whether key usages should be present in the CertificateRequest
+     * Whether key usages should be present in the CertificateRequest
      */
     @WithDefault("false")
     boolean encodeUsagesInRequest();
 
     /**
-     * @return the mount path where the generated certificate resources will be mounted.
+     * The mount path where the generated certificate resources will be mounted.
      */
     @WithDefault("/etc/certs")
     String volumeMountPath();
 
     /**
-     * @return whether to populate the HTTP SSL configuration as described in
-     *         <a href="https://quarkus.io/guides/http-reference#providing-a-keystore">here</a>.
+     * Whether to populate the HTTP SSL configuration as described in
+     * <a href="https://quarkus.io/guides/http-reference#providing-a-keystore">here</a>.
      */
     @WithDefault("AUTOMATIC")
     AutoConfigureMode autoconfigure();

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateKeystoreConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateKeystoreConfig.java
@@ -1,8 +1,5 @@
 package io.quarkiverse.certmanager.deployment;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface CertificateKeystoreConfig {
     /**
      * Create enables keystore creation for the Certificate.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateKeystoresConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificateKeystoresConfig.java
@@ -2,9 +2,6 @@ package io.quarkiverse.certmanager.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface CertificateKeystoresConfig {
     /**
      * JKS configures options for storing a JKS keystore in the spec.secretName Secret resource.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificatePrivateKeyConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/CertificatePrivateKeyConfig.java
@@ -3,10 +3,8 @@ package io.quarkiverse.certmanager.deployment;
 import io.dekorate.certmanager.annotation.PrivateKeyAlgorithm;
 import io.dekorate.certmanager.annotation.PrivateKeyEncoding;
 import io.dekorate.certmanager.annotation.RotationPolicy;
-import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigGroup
 public interface CertificatePrivateKeyConfig {
     /**
      * RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed.
@@ -15,19 +13,19 @@ public interface CertificatePrivateKeyConfig {
     RotationPolicy rotationPolicy();
 
     /**
-     * @return the private key cryptography standards (PKCS) encoding for this certificate’s private key to be encoded in.
+     * The private key cryptography standards (PKCS) encoding for this certificate’s private key to be encoded in.
      */
     @WithDefault("Unset")
     PrivateKeyEncoding encoding();
 
     /**
-     * @return the private key algorithm of the corresponding private key for this certificate.
+     * The private key algorithm of the corresponding private key for this certificate.
      */
     @WithDefault("Unset")
     PrivateKeyAlgorithm algorithm();
 
     /**
-     * @return the key bit size of the corresponding private key for this certificate.
+     * The key bit size of the corresponding private key for this certificate.
      */
     @WithDefault("-1")
     int size();

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/IssuerRefConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/IssuerRefConfig.java
@@ -2,9 +2,6 @@ package io.quarkiverse.certmanager.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface IssuerRefConfig {
     /**
      * The name of the resource being referred to.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/LocalObjectReferenceConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/LocalObjectReferenceConfig.java
@@ -1,8 +1,5 @@
 package io.quarkiverse.certmanager.deployment;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface LocalObjectReferenceConfig {
     /**
      * The name of the resource being referred to.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/SelfSignedConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/SelfSignedConfig.java
@@ -3,9 +3,6 @@ package io.quarkiverse.certmanager.deployment;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface SelfSignedConfig {
 
     /**

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/SubjectConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/SubjectConfig.java
@@ -3,9 +3,6 @@ package io.quarkiverse.certmanager.deployment;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface SubjectConfig {
     /**
      * The organizations to be used on the Certificate.

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultAppRoleConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultAppRoleConfig.java
@@ -2,9 +2,6 @@ package io.quarkiverse.certmanager.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface VaultAppRoleConfig {
     /**
      * The App Role authentication backend is mounted in Vault, e.g: “approle”

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultConfig.java
@@ -2,9 +2,6 @@ package io.quarkiverse.certmanager.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface VaultConfig {
     /**
      * The connection address for the Vault server, e.g: “https://vault.example.com:8200”.
@@ -33,7 +30,7 @@ public interface VaultConfig {
     Optional<VaultKubernetesAuthConfig> authKubernetes();
 
     /**
-     * @return the vault namespace.
+     * The vault namespace.
      */
     Optional<String> namespace();
 

--- a/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultKubernetesAuthConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/certmanager/deployment/VaultKubernetesAuthConfig.java
@@ -2,9 +2,6 @@ package io.quarkiverse.certmanager.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-
-@ConfigGroup
 public interface VaultKubernetesAuthConfig {
     /**
      * The mount path to use when authenticating with Vault.

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.7.0
+:quarkus-version: 3.16.0
 :quarkus-certmanager-version: 1.0.2
 :maven-version: 3.8.1+
 

--- a/integration-tests/kubernetes-certmanager-ssl/pom.xml
+++ b/integration-tests/kubernetes-certmanager-ssl/pom.xml
@@ -13,7 +13,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
 
     <dependency>

--- a/integration-tests/openshift-certmanager-ssl/pom.xml
+++ b/integration-tests/openshift-certmanager-ssl/pom.xml
@@ -13,7 +13,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.1</quarkus.version>
+    <quarkus.version>3.16.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Bumps `quarkus.version` from 3.15.1 to 3.16.0.
Updates `io.quarkus:quarkus-bom` from 3.15.1 to 3.16.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/quarkusio/quarkus/releases">io.quarkus:quarkus-bom's releases</a>.</em></p>
<blockquote>
<h2>3.16.0.CR1</h2>
<h3>Major changes</h3>
<ul>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/38239">#38239</a> - Logging OpenTelemetry extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/41264">#41264</a> - LGTM Quarkus Dashboard</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/41866">#41866</a> - Add quarkus-oidc-client-registration extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42642">#42642</a> - Support record parameter containers</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42749">#42749</a> - Add new AuthorizationPolicy annotation to bind named HttpSecurityPolicy to a Jakarta REST endpoints</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42879">#42879</a> - Add OIDC Client SPI</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42935">#42935</a> - Support for two or more authentications for a single request</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43005">#43005</a> - Drop the compatibility layer for the Big Reactive Rename</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43241">#43241</a> - Support <code>@PermissionsAllowed</code> defined on meta-annotation</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43283">#43283</a> - Introduce OidcResponseFilter</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43331">#43331</a> - Introduce per invocation override of REST Client's base URL</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43402">#43402</a> - Auto log for dev services in containers</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43441">#43441</a> - Add HTTP Access Log to Dev UI</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43609">#43609</a> - Support Keycloak Dev Service when OIDC client is used without OIDC extension</li>
</ul>
<h3>Complete changelog</h3>
<ul>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/10435">#10435</a> - Misconfigured TCCL for <code>@TestFactory</code> dynamic tests breaks RestAssured since Quarkus 1.5.0</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/19686">#19686</a> - Support constructor injection for RESTEasy Reactive multipart bodies</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/22824">#22824</a> - Add jitter to scheduler</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/23559">#23559</a> - Buildpack for Quarkus/Quarkus Native</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/23883">#23883</a> - When using buildpack without docker running gets a meaningless exception</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/24378">#24378</a> - KafkaDevServicesContinuousTestingWorkingAppPropsTestCase / PriceResourceET do not indicate recovery is tested, logs with test errors</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/25496">#25496</a> - When using reactive restclient in 2.8.2.Final with Response, getEntity() returns null even if there is a body in Response</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/27326">#27326</a> - MongoDB panache generates invalid update documents when updating a list or array with HQL</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/29191">#29191</a> - Subscribing to <code>CompletionStage</code> returned by <code>Event.fireAsync</code> doesn't seem to work correctly</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/30712">#30712</a> - Support OpenTelemetry Log signal</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/31328">#31328</a> - Support for inclusive authentication</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/32143">#32143</a> - OIDC document shoud update</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/32159">#32159</a> - Redis client with AWS Elasticache</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/33018">#33018</a> - ServletContextInitializer IT test</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/33665">#33665</a> - Clarify the behavior of <code>InstanceHandle.close()</code></li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/33666">#33666</a> - Clarify class-level interceptor binding inheritance</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/35871">#35871</a> - Jackson <code>@JsonView</code> deserialization support for request bodies</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/36227">#36227</a> - Accept-Language header not parsed correctly for language subtags, variants, extension and private subtags</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/36228">#36228</a> - Use java.util.Locale to parse the languages from the Accept-Language header</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/36336">#36336</a> - <code>@CacheResult</code> on legacy <code>@RegisterRestClient</code> throws CCE on 3.4.2</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/37243">#37243</a> - Enhance keycloak-admin-client extension to support TLS trust and key stores</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/37777">#37777</a> - Building Quarkus with Buildpacks uses Liberica as JDK</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38228">#38228</a> - Better support for APT in dev mode: Gradle part</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/38239">#38239</a> - Logging OpenTelemetry extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38250">#38250</a> - Support for OIDC Dynamic Client Registration</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38814">#38814</a> - Memory usage increased between Quarkus 3.6 and 3.7</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/39663">#39663</a> - Security - Ability to create custom permission annotation</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/39950">#39950</a> - File and FileUpload result in different OpenAPI spec, upload button missing</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/40007">#40007</a> - Add ability to hide rest endpoints from OpenAPI schema / Swagger</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/40829">#40829</a> - dynamic default page can't handle I add a index.html file</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/quarkusio/quarkus/commit/06af1631119364d316a861f12bbb280000ebed85"><code>06af163</code></a> [RELEASE] - Bump version to 3.16.0</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/9c118bcd6968467cb16733177b965ae95876ef58"><code>9c118bc</code></a> Merge pull request <a href="https://redirect.github.com/quarkusio/quarkus/issues/44036">#44036</a> from gsmet/3.16.0-backports-2</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/cf6b2fea097785a94df080abb80bb46f924aae9d"><code>cf6b2fe</code></a> renaming to library</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/1c9483d193a5d3fafe02e3debaa1824c0974b162"><code>1c9483d</code></a> avoiding forcing resolution when configuring QuarkusApplicationModelTask</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/5c11e570c5e05bd0cc22b2537dea9d868581252f"><code>5c11e57</code></a> Fix for issue 42549 - replaces oidc authentication for github screenshots wit...</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/3b0b8d860742cfc52e804cb0066237c6ca9a2ded"><code>3b0b8d8</code></a> Docs typo fixes - specificed, agrument</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/2e764f8409d13d55f75f550f64699e7f6334d556"><code>2e764f8</code></a> Add RESTEasy Multipart capability</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/60b802ad554430962cc8c72eea03b0dd1ca970ab"><code>60b802a</code></a> Work around failure of maturity model PR to merge</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/9b14a316fc3bd64ff2a2c700128286f4fc82de9e"><code>9b14a31</code></a> Skeleton extensions FAQ</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/20baabec19c5914bb7a680b4c8eb27c073e09465"><code>20baabe</code></a> Merge pull request <a href="https://redirect.github.com/quarkusio/quarkus/issues/44002">#44002</a> from gsmet/3.16.0-backports-1</li>
<li>Additional commits viewable in <a href="https://github.com/quarkusio/quarkus/compare/3.15.1...3.16.0">compare view</a></li>
</ul>
</details>
<br />

Updates `io.quarkus:quarkus-maven-plugin` from 3.15.1 to 3.16.0

Updates `io.quarkus:quarkus-extension-processor` from 3.15.1 to 3.16.0

Updates `io.quarkus:quarkus-extension-maven-plugin` from 3.15.1 to 3.16.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/quarkusio/quarkus/releases">io.quarkus:quarkus-extension-maven-plugin's releases</a>.</em></p>
<blockquote>
<h2>3.16.0.CR1</h2>
<h3>Major changes</h3>
<ul>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/38239">#38239</a> - Logging OpenTelemetry extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/41264">#41264</a> - LGTM Quarkus Dashboard</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/41866">#41866</a> - Add quarkus-oidc-client-registration extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42642">#42642</a> - Support record parameter containers</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42749">#42749</a> - Add new AuthorizationPolicy annotation to bind named HttpSecurityPolicy to a Jakarta REST endpoints</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42879">#42879</a> - Add OIDC Client SPI</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/42935">#42935</a> - Support for two or more authentications for a single request</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43005">#43005</a> - Drop the compatibility layer for the Big Reactive Rename</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43241">#43241</a> - Support <code>@PermissionsAllowed</code> defined on meta-annotation</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43283">#43283</a> - Introduce OidcResponseFilter</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43331">#43331</a> - Introduce per invocation override of REST Client's base URL</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43402">#43402</a> - Auto log for dev services in containers</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43441">#43441</a> - Add HTTP Access Log to Dev UI</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/43609">#43609</a> - Support Keycloak Dev Service when OIDC client is used without OIDC extension</li>
</ul>
<h3>Complete changelog</h3>
<ul>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/10435">#10435</a> - Misconfigured TCCL for <code>@TestFactory</code> dynamic tests breaks RestAssured since Quarkus 1.5.0</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/19686">#19686</a> - Support constructor injection for RESTEasy Reactive multipart bodies</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/22824">#22824</a> - Add jitter to scheduler</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/23559">#23559</a> - Buildpack for Quarkus/Quarkus Native</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/23883">#23883</a> - When using buildpack without docker running gets a meaningless exception</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/24378">#24378</a> - KafkaDevServicesContinuousTestingWorkingAppPropsTestCase / PriceResourceET do not indicate recovery is tested, logs with test errors</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/25496">#25496</a> - When using reactive restclient in 2.8.2.Final with Response, getEntity() returns null even if there is a body in Response</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/27326">#27326</a> - MongoDB panache generates invalid update documents when updating a list or array with HQL</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/29191">#29191</a> - Subscribing to <code>CompletionStage</code> returned by <code>Event.fireAsync</code> doesn't seem to work correctly</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/30712">#30712</a> - Support OpenTelemetry Log signal</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/31328">#31328</a> - Support for inclusive authentication</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/32143">#32143</a> - OIDC document shoud update</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/32159">#32159</a> - Redis client with AWS Elasticache</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/33018">#33018</a> - ServletContextInitializer IT test</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/33665">#33665</a> - Clarify the behavior of <code>InstanceHandle.close()</code></li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/33666">#33666</a> - Clarify class-level interceptor binding inheritance</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/35871">#35871</a> - Jackson <code>@JsonView</code> deserialization support for request bodies</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/36227">#36227</a> - Accept-Language header not parsed correctly for language subtags, variants, extension and private subtags</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/36228">#36228</a> - Use java.util.Locale to parse the languages from the Accept-Language header</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/36336">#36336</a> - <code>@CacheResult</code> on legacy <code>@RegisterRestClient</code> throws CCE on 3.4.2</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/37243">#37243</a> - Enhance keycloak-admin-client extension to support TLS trust and key stores</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/37777">#37777</a> - Building Quarkus with Buildpacks uses Liberica as JDK</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38228">#38228</a> - Better support for APT in dev mode: Gradle part</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/pull/38239">#38239</a> - Logging OpenTelemetry extension</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38250">#38250</a> - Support for OIDC Dynamic Client Registration</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/38814">#38814</a> - Memory usage increased between Quarkus 3.6 and 3.7</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/39663">#39663</a> - Security - Ability to create custom permission annotation</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/39950">#39950</a> - File and FileUpload result in different OpenAPI spec, upload button missing</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/40007">#40007</a> - Add ability to hide rest endpoints from OpenAPI schema / Swagger</li>
<li><a href="https://redirect.github.com/quarkusio/quarkus/issues/40829">#40829</a> - dynamic default page can't handle I add a index.html file</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/quarkusio/quarkus/commit/06af1631119364d316a861f12bbb280000ebed85"><code>06af163</code></a> [RELEASE] - Bump version to 3.16.0</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/9c118bcd6968467cb16733177b965ae95876ef58"><code>9c118bc</code></a> Merge pull request <a href="https://redirect.github.com/quarkusio/quarkus/issues/44036">#44036</a> from gsmet/3.16.0-backports-2</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/cf6b2fea097785a94df080abb80bb46f924aae9d"><code>cf6b2fe</code></a> renaming to library</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/1c9483d193a5d3fafe02e3debaa1824c0974b162"><code>1c9483d</code></a> avoiding forcing resolution when configuring QuarkusApplicationModelTask</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/5c11e570c5e05bd0cc22b2537dea9d868581252f"><code>5c11e57</code></a> Fix for issue 42549 - replaces oidc authentication for github screenshots wit...</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/3b0b8d860742cfc52e804cb0066237c6ca9a2ded"><code>3b0b8d8</code></a> Docs typo fixes - specificed, agrument</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/2e764f8409d13d55f75f550f64699e7f6334d556"><code>2e764f8</code></a> Add RESTEasy Multipart capability</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/60b802ad554430962cc8c72eea03b0dd1ca970ab"><code>60b802a</code></a> Work around failure of maturity model PR to merge</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/9b14a316fc3bd64ff2a2c700128286f4fc82de9e"><code>9b14a31</code></a> Skeleton extensions FAQ</li>
<li><a href="https://github.com/quarkusio/quarkus/commit/20baabec19c5914bb7a680b4c8eb27c073e09465"><code>20baabe</code></a> Merge pull request <a href="https://redirect.github.com/quarkusio/quarkus/issues/44002">#44002</a> from gsmet/3.16.0-backports-1</li>
<li>Additional commits viewable in <a href="https://github.com/quarkusio/quarkus/compare/3.15.1...3.16.0">compare view</a></li>
</ul>
</details>
<br />